### PR TITLE
fix disk template

### DIFF
--- a/prod/main.tf
+++ b/prod/main.tf
@@ -247,7 +247,7 @@ resource "google_compute_instance_template" "foody_instance_template" {
   disk {
     auto_delete = true
     boot        = true
-    source      = "projects/debian-cloud/global/images/family/debian-12"
+    source_image = "debian-cloud/debian-12"
     disk_size_gb = 30
     type         = "pd-standard"
     disk_name   = "foody-disk"


### PR DESCRIPTION
This pull request includes a change to the `prod/main.tf` file to update the source image reference for the Google Compute Engine instance template.

* [`prod/main.tf`](diffhunk://#diff-3b117c268bfb686cd17f1c178156fd519943e2a90eaab366da07d71f4d2dfb9cL250-R250): Updated the `source` attribute to `source_image` with the value `debian-cloud/debian-12` in the `google_compute_instance_template` resource.