### PR TITLE
Updated Grocery-be service limit

### DIFF
--- a/prod/main.tf
+++ b/prod/main.tf
@@ -204,7 +204,7 @@ resource "google_cloud_run_v2_service" "grocery_be" {
         cpu_idle = true
         limits = {
           cpu    = "1000m"
-          memory = "512Mi"
+          memory = "1024Mi"
         }
         startup_cpu_boost = true
       }


### PR DESCRIPTION
This pull request includes a change to the `prod/main.tf` file to adjust the memory allocation for the `google_cloud_run_v2_service` resource.

Resource configuration update:

* Increased the memory limit for the `google_cloud_run_v2_service` resource from `512Mi` to `1024Mi`.